### PR TITLE
allow disabled checkboxes in checkbox tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reonomy/styles",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Reonomy Design Styles Library",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/components/checkbox-tree/CheckboxTree.stories.tsx
+++ b/src/components/checkbox-tree/CheckboxTree.stories.tsx
@@ -108,3 +108,119 @@ WithRootLevelClosed.args = {
     console.log('new data >>', data);
   }
 };
+
+export const WithIndeterminateRootLevelPartialDisabledChildren = Template.bind({});
+WithIndeterminateRootLevelPartialDisabledChildren.args = {
+  data: {
+    name: '1',
+    label: 'one',
+    checked: null,
+    children: [
+      {
+        name: '2',
+        label: 'two',
+        checked: false
+      },
+      {
+        name: '3',
+        label: 'three',
+        checked: true,
+        disabled: true
+      },
+      {
+        name: '4',
+        label: 'four',
+        checked: false,
+        disabled: true
+      },
+      {
+        name: '5',
+        label: 'five',
+        checked: false,
+        disabled: false
+      }
+    ]
+  },
+  open: true,
+  onUpdate: (data: TreeData) => {
+    console.log('new data >>', data);
+  }
+};
+
+export const WithDisabledIndeterminateRootDisabledChildren = Template.bind({});
+WithDisabledIndeterminateRootDisabledChildren.args = {
+  data: {
+    name: '1',
+    label: 'one',
+    checked: null,
+    disabled: true,
+    children: [
+      {
+        name: '2',
+        label: 'two',
+        checked: false
+      },
+      {
+        name: '3',
+        label: 'three',
+        checked: true,
+        disabled: true
+      },
+      {
+        name: '4',
+        label: 'four',
+        checked: false,
+        disabled: true
+      },
+      {
+        name: '5',
+        label: 'five',
+        checked: false,
+        disabled: false
+      }
+    ]
+  },
+  open: true,
+  onUpdate: (data: TreeData) => {
+    console.log('new data >>', data);
+  }
+};
+
+export const WithDisabledRootAllowAllChildrenChecked = Template.bind({});
+WithDisabledRootAllowAllChildrenChecked.args = {
+  data: {
+    name: '1',
+    label: 'one',
+    checked: null,
+    disabled: true,
+    children: [
+      {
+        name: '2',
+        label: 'two',
+        checked: false
+      },
+      {
+        name: '3',
+        label: 'three',
+        checked: true,
+        disabled: true
+      },
+      {
+        name: '4',
+        label: 'four',
+        checked: true,
+        disabled: true
+      },
+      {
+        name: '5',
+        label: 'five',
+        checked: false,
+        disabled: false
+      }
+    ]
+  },
+  open: true,
+  onUpdate: (data: TreeData) => {
+    console.log('new data >>', data);
+  }
+};

--- a/src/components/checkbox-tree/CheckboxTree.tsx
+++ b/src/components/checkbox-tree/CheckboxTree.tsx
@@ -13,6 +13,7 @@ export interface TreeData {
   name: string;
   label: string;
   checked: boolean | null;
+  disabled?: boolean;
   children?: TreeData[];
 }
 
@@ -38,8 +39,9 @@ export function CheckboxWrapper({
   openCheckboxGroup
 }: CheckboxWrapperProps) {
   const classes: StyleClasses = useStyles({ level } as StyleProps);
-  const allChildrenChecked = data?.children?.every(child => child.checked);
-  const hasOneAndNotAllChecked = data.children && data.children.some(child => child.checked) && !allChildrenChecked;
+  const allChildrenChecked = data?.children?.every(child => child.checked || child.disabled);
+  const hasOneAndNotAllChecked =
+    data.children && data.children.some(child => child.checked || child.disabled) && !allChildrenChecked;
   const checkboxName = data.label.toLowerCase().replace(/ /g, '');
 
   const openIcon = open ? (
@@ -76,6 +78,7 @@ export function CheckboxWrapper({
             color="default"
             checked={level === 0 ? allChildrenChecked : !!data.checked}
             className={level === 0 ? classes.parent : classes.child}
+            disabled={data.disabled}
             indeterminate={level === 0 && hasOneAndNotAllChecked}
             name={checkboxName}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => onChange(event, data)}

--- a/src/components/checkbox-tree/UseCheckboxTree.tsx
+++ b/src/components/checkbox-tree/UseCheckboxTree.tsx
@@ -50,10 +50,12 @@ function checkboxTreeReducer(state: CheckboxTreeState, action: Actions.CheckboxT
         ...state,
         data: {
           ...state.data,
-          checked: true,
+          checked: (state?.data?.children || []).some(child => {
+            return child.disabled;
+          }),
           children: (state?.data?.children || []).map(child => ({
             ...child,
-            checked: true
+            checked: child.disabled ? child.checked : true
           }))
         }
       };
@@ -65,7 +67,7 @@ function checkboxTreeReducer(state: CheckboxTreeState, action: Actions.CheckboxT
           checked: false,
           children: (state?.data?.children || []).map(child => ({
             ...child,
-            checked: false
+            checked: child.disabled ? child.checked : false
           }))
         }
       };


### PR DESCRIPTION
to support editable-columns-table-view, I've added functionality to allow disabled checkboxes in the filetree.  specifically, the address checkbox will be disabled.

can see the new scenarios in storybook.

Notably, root can be disabled.
Indeterminate state accounts for disabled children as well.