### PR TITLE
new text component

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ This will generate a .tgz file top level you can now update reference to in /exa
 
 Update /example/public/index.html as needed, and ensure visual styles are as expected.
 
-Delete old .tgz file versions for good housekeeping.
+To test in visage locally, simply reference this file from the visage directory in the visage package.json:
+
+```js
+"@reonomy/styles": "../../../styles/reonomy-styles-1.0.5.tgz",
+```
+
+Delete any old .tgz files before generating packing new versions (as they will be included in the bundle).
 
 You may periodically need to clear the yarn cache with:
 

--- a/example/app.js
+++ b/example/app.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 
 import ReonomyStyles, {
   CheckboxTree,
+  Text,
   IconAddSolid,
   IconArrowDownSolid,
   IconArrowUpSolid,
@@ -162,14 +163,14 @@ import ReonomyStyles, {
   IconRefreshOutline,
   IconLinkOutline
 } from '@reonomy/styles';
-import { Button, IconButton, Typography } from '@material-ui/core';
+import { Button, IconButton } from '@material-ui/core';
 
 const HelloWorld = () => {
   return (
     <ReonomyStyles>
       <main style={{ padding: 150 }}>
-        <Typography variant="h1">Hello World, I should be Basier Square</Typography>
-        <Typography>These leader lines should look not broken:</Typography>
+        <Text variant="h1">Hello World, I should be Basier Square</Text>
+        <Text>These leader lines should look not broken:</Text>
         <article style={{ width: 350, padding: 20, background: 'white' }}>
           <dl className="leader-lines">
             <dt>Lot Area SF</dt>
@@ -201,7 +202,7 @@ const HelloWorld = () => {
           </dl>
         </article>
 
-        <Typography variant="h5">These buttons should be colorful and hoverable:</Typography>
+        <Text variant="h5">These buttons should be colorful and hoverable:</Text>
         <article>
           <Button variant="contained" className="label-style-0">
             Style 0
@@ -229,14 +230,14 @@ const HelloWorld = () => {
           </Button>
         </article>
 
-        <Typography variant="h5">And hey look, a spinning ampersand:</Typography>
+        <Text variant="h5">And hey look, a spinning ampersand:</Text>
         <article>
           <div className="icon-spin" style={{ background: 'white', boxShadow: '0 0 5px rgba(0,0,0,0.2)' }}>
             @
           </div>
         </article>
 
-        <Typography variant="h5">MTA icons, for your pleasure:</Typography>
+        <Text variant="h5">MTA icons, for your pleasure:</Text>
         <article>
           <div>
             <span className="subway-icon mta-green">6</span>
@@ -263,11 +264,11 @@ const HelloWorld = () => {
           </div>
         </article>
 
-        <Typography variant="h5" gutterBottom>
+        <Text variant="h5" gutterBottom>
           IonIcons
-        </Typography>
+        </Text>
         <article>
-          <Typography>Solid Icons</Typography>
+          <Text>Solid Icons</Text>
           <IconAddSolid />
           <IconArrowDownSolid />
           <IconArrowUpSolid />
@@ -347,7 +348,7 @@ const HelloWorld = () => {
           <IconWarningSolid />
         </article>
         <article>
-          <Typography>Outline Icons</Typography>
+          <Text>Outline Icons</Text>
           <IconAddOutline />
           <IconArrowDownOutline />
           <IconArrowUpOutline />
@@ -430,24 +431,24 @@ const HelloWorld = () => {
           <IconRefreshOutline />
           <IconLinkOutline />
         </article>
-        <Typography variant="h2" color="primary">
+        <Text variant="h2" color="primary">
           I am primary color h2 with icon <IconTodaySolid fontSize="inherit" />
-        </Typography>
-        <Typography variant="subtitle1" color="secondary">
+        </Text>
+        <Text variant="subtitle1" color="secondary">
           I am a secondary color subtitle1 with icon <IconTodaySolid fontSize="inherit" />
-        </Typography>
-        <Typography variant="subtitle2" color="textSecondary">
+        </Text>
+        <Text variant="subtitle2" color="textSecondary">
           I am a textSecondary color subtitle2 with icon <IconTodaySolid fontSize="inherit" />
-        </Typography>
-        <Typography>
-          I am a default body color paragraph with icon <IconTodaySolid fontSize="inherit" />
-        </Typography>
-        <Typography>
+        </Text>
+        <Text variant="body1" fontWeight="medium">
+          I am a bolder default body color paragraph with icon <IconTodaySolid fontSize="inherit" />
+        </Text>
+        <Text>
           And here is an IconButton:
           <IconButton>
             <IconTodaySolid fontSize="inherit" />
           </IconButton>
-        </Typography>
+        </Text>
         <CheckboxTree
           data={{
             id: '1',

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@material-ui/core": "^4.11.1",
-    "@reonomy/styles": "../reonomy-styles-2.0.0.tgz",
+    "@reonomy/styles": "../reonomy-styles-2.5.0.tgz",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reonomy/styles",
-  "version": "2.2.1",
+  "version": "2.5.0",
   "description": "Reonomy Design Styles Library",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reonomy/styles",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "description": "Reonomy Design Styles Library",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/components/checkbox-tree/CheckboxTree.stories.tsx
+++ b/src/components/checkbox-tree/CheckboxTree.stories.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { CheckboxTree, CheckboxTreeProps, TreeData } from './CheckboxTree';
+import ReonomyStyles from '../..';
 
 export default {
   title: 'Components/CheckboxTree',
   component: CheckboxTree
 } as Meta;
 
-const Template: Story<CheckboxTreeProps> = args => <CheckboxTree {...args} />;
+const Template: Story<CheckboxTreeProps> = args => (
+  <ReonomyStyles>
+    <CheckboxTree {...args} />
+  </ReonomyStyles>
+);
 
 export const AllChecked = Template.bind({});
 AllChecked.args = {

--- a/src/components/checkbox/index.stories.tsx
+++ b/src/components/checkbox/index.stories.tsx
@@ -2,13 +2,18 @@ import React from 'react';
 import { CheckboxProps } from '@material-ui/core';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Checkbox } from '.';
+import ReonomyStyles from '../..';
 
 export default {
   title: 'Components/Checkbox',
   component: Checkbox
 } as Meta;
 
-const Template: Story<CheckboxProps> = args => <Checkbox {...args} />;
+const Template: Story<CheckboxProps> = args => (
+  <ReonomyStyles>
+    <Checkbox {...args} />
+  </ReonomyStyles>
+);
 
 export const Checked = Template.bind({});
 Checked.args = {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
+export { Text } from './text';
 export * from './checkbox-tree/CheckboxTree';

--- a/src/components/text/index.stories.tsx
+++ b/src/components/text/index.stories.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import { Text } from '.';
+import { Text as ReonomyText, TextProps } from '.';
+import ReonomyStyles from '../..';
 
 export default {
   title: 'Components/Text',
-  component: Text
+  component: ReonomyText
 } as Meta;
+
+function Text({ children, ...props }: { children: React.ReactNode } & TextProps) {
+  return (
+    <ReonomyStyles>
+      <ReonomyText {...props}>{children}</ReonomyText>
+    </ReonomyStyles>
+  );
+}
 
 export const Huge = () => <Text variant="huge">Huge</Text>;
 export const H1 = () => <Text variant="h1">h1</Text>;
@@ -16,11 +25,7 @@ export const H5 = () => <Text variant="h5">h5</Text>;
 export const H6 = () => <Text variant="h6">h6</Text>;
 export const Subtitle1 = () => <Text variant="subtitle1">Subtitle 1</Text>;
 export const Subtitle2 = () => <Text variant="subtitle2">Subtitle 2</Text>;
-export const Body1 = () => (
-  <Text variant="body1" gutterLeft>
-    Body 1
-  </Text>
-);
+export const Body1 = () => <Text variant="body1">Body 1</Text>;
 export const Body2 = () => <Text variant="body2">Body 2</Text>;
 export const Overline = () => <Text variant="overline">overline</Text>;
 export const Code = () => <Text variant="code">code</Text>;

--- a/src/components/text/index.stories.tsx
+++ b/src/components/text/index.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import { Text } from '.';
+
+export default {
+  title: 'Components/Text',
+  component: Text
+} as Meta;
+
+export const Huge = () => <Text variant="huge">Huge</Text>;
+export const H1 = () => <Text variant="h1">h1</Text>;
+export const H2 = () => <Text variant="h2">h2</Text>;
+export const H3 = () => <Text variant="h3">h3</Text>;
+export const H4 = () => <Text variant="h4">h4</Text>;
+export const H5 = () => <Text variant="h5">h5</Text>;
+export const H6 = () => <Text variant="h6">h6</Text>;
+export const Subtitle1 = () => <Text variant="subtitle1">Subtitle 1</Text>;
+export const Subtitle2 = () => <Text variant="subtitle2">Subtitle 2</Text>;
+export const Body1 = () => (
+  <Text variant="body1" gutterLeft>
+    Body 1
+  </Text>
+);
+export const Body2 = () => <Text variant="body2">Body 2</Text>;
+export const Overline = () => <Text variant="overline">overline</Text>;
+export const Code = () => <Text variant="code">code</Text>;

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Typography, TypographyProps } from '@material-ui/core';
 import useStyles, { StyleClasses } from './style';
 
-interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
+export interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
   gutterBottom?: boolean;
   gutterTop?: boolean;
   gutterLeft?: boolean;

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Typography, TypographyProps } from '@material-ui/core';
 import useStyles, { StyleClasses } from './style';
 
+type MuiVariant = Exclude<TypographyProps['variant'], 'button'>;
+
 export interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
   gutterBottom?: boolean;
   gutterTop?: boolean;
@@ -10,9 +12,9 @@ export interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
   gutters?: boolean;
   padded?: boolean;
   fontWeight?: 'regular' | 'medium' | 'semibold'; // 400, 500, 600
-  variant?: TypographyProps['variant'] | 'huge' | 'code';
+  variant?: MuiVariant | 'huge' | 'code';
   color?: TypographyProps['color'] | 'textDisabled' | 'textHint';
-  component?: React.ElementType<any>;
+  component?: React.ElementType;
 }
 
 export function Text({
@@ -27,11 +29,12 @@ export function Text({
   fontWeight,
   color,
   component: elementType,
+  className,
   ...muiProps
 }: TextProps) {
   const classes: StyleClasses = useStyles();
   const classNames: string[] = [];
-  let muiVariant: TypographyProps['variant'];
+  let muiVariant: MuiVariant;
   let muiColor: TypographyProps['color'];
   let component = elementType;
 
@@ -47,6 +50,7 @@ export function Text({
     case 'code':
       classNames.push(classes.code);
       component = component || 'code';
+      muiVariant = 'body2';
       break;
     default:
       muiVariant = variant;
@@ -76,6 +80,8 @@ export function Text({
     default:
       muiColor = color;
   }
+
+  if (className) classNames.push(className);
 
   return (
     <Typography variant={muiVariant} color={muiColor} className={classNames.join(' ')} {...{ component }} {...muiProps}>

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Typography, TypographyProps } from '@material-ui/core';
+import useStyles, { StyleClasses } from './style';
+
+interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
+  gutterBottom?: boolean;
+  gutterTop?: boolean;
+  gutterLeft?: boolean;
+  gutterRight?: boolean;
+  gutters?: boolean;
+  padded?: boolean;
+  fontWeight?: 'regular' | 'medium' | 'semibold'; // 400, 500, 600
+  variant?: TypographyProps['variant'] | 'huge' | 'code';
+  color?: TypographyProps['color'] | 'textDisabled' | 'textHint';
+  component?: React.ElementType<any>;
+}
+
+export function Text({
+  children,
+  gutterBottom,
+  gutterTop,
+  gutterLeft,
+  gutterRight,
+  gutters,
+  padded,
+  variant,
+  fontWeight,
+  color,
+  component: elementType,
+  ...muiProps
+}: TextProps) {
+  const classes: StyleClasses = useStyles();
+  const classNames: string[] = [];
+  let muiVariant: TypographyProps['variant'];
+  let muiColor: TypographyProps['color'];
+  let component = elementType;
+
+  Object.entries({ gutterBottom, gutterTop, gutterLeft, gutterRight, gutters, padded }).forEach(([name, value]) => {
+    if (value) classNames.push(classes[name as keyof StyleClasses]);
+  });
+
+  switch (variant) {
+    case 'huge':
+      classNames.push(classes.huge);
+      muiVariant = 'h1';
+      break;
+    case 'code':
+      classNames.push(classes.code);
+      component = component || 'code';
+      break;
+    default:
+      muiVariant = variant;
+  }
+
+  switch (fontWeight) {
+    case 'medium':
+      classNames.push(classes.fontWeightMedium);
+      break;
+    case 'regular':
+      classNames.push(classes.fontWeightRegular);
+      break;
+    case 'semibold':
+      classNames.push(classes.fontWeightSemiBold);
+      break;
+    default:
+      break;
+  }
+
+  switch (color) {
+    case 'textDisabled':
+      classNames.push(classes.textDisabled);
+      break;
+    case 'textHint':
+      classNames.push(classes.textHint);
+      break;
+    default:
+      muiColor = color;
+  }
+
+  return (
+    <Typography variant={muiVariant} color={muiColor} className={classNames.join(' ')} {...{ component }} {...muiProps}>
+      {children}
+    </Typography>
+  );
+}

--- a/src/components/text/style.ts
+++ b/src/components/text/style.ts
@@ -1,0 +1,62 @@
+import { makeStyles, Theme } from '@material-ui/core';
+
+export interface StyleClasses {
+  gutterBottom: string;
+  gutterTop: string;
+  gutterLeft: string;
+  gutterRight: string;
+  gutters: string;
+  padded: string;
+  huge: string;
+  code: string;
+  fontWeightMedium: string;
+  fontWeightRegular: string;
+  fontWeightSemiBold: string;
+  textDisabled: string;
+  textHint: string;
+}
+
+export default makeStyles((theme: Theme) => {
+  return {
+    gutterBottom: {
+      marginBottom: theme.spacing(2)
+    },
+    gutterTop: {
+      marginTop: theme.spacing(2)
+    },
+    gutterLeft: {
+      marginLeft: theme.spacing(2)
+    },
+    gutterRight: {
+      marginRight: theme.spacing(2)
+    },
+    gutters: {
+      margin: theme.spacing(2)
+    },
+    padded: {
+      padding: theme.spacing(2)
+    },
+    huge: {
+      fontSize: '9rem',
+      fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif"
+    },
+    code: {
+      fontFamily: 'monospace, monaco, courier'
+    },
+    fontWeightMedium: {
+      fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif"
+    },
+    fontWeightRegular: {
+      fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif"
+    },
+    fontWeightSemiBold: {
+      fontFamily: "'Basier Square SemiBold', Helvetica, Arial, sans-serif"
+    },
+    textDisabled: {
+      color: theme.palette.text.disabled
+    },
+    textHint: {
+      color: theme.palette.text.hint
+    }
+  };
+});

--- a/src/components/text/style.ts
+++ b/src/components/text/style.ts
@@ -37,8 +37,9 @@ export default makeStyles((theme: Theme) => {
       padding: theme.spacing(2)
     },
     huge: {
+      fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif",
       fontSize: '9rem',
-      fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif"
+      letterSpacing: -5
     },
     code: {
       fontFamily: 'monospace, monaco, courier'

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -201,6 +201,17 @@ const ReonomyTheme = createMuiTheme({
         }
       }
     },
+    MuiTab: {
+      root: {
+        fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif",
+        '&$selected': {
+          fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif"
+        },
+        '@media (min-width: 600px)': {
+          minWidth: 'auto'
+        }
+      }
+    },
     MuiTooltip: {
       tooltip: {
         fontSize: '.875rem'

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -90,7 +90,7 @@ const ReonomyTheme = createMuiTheme({
     body2: {
       fontSize: '.875rem',
       fontWeight: 'normal',
-      lineHeight: 1.715,
+      lineHeight: 1.5,
       letterSpacing: 0.5
     },
     button: {
@@ -203,9 +203,7 @@ const ReonomyTheme = createMuiTheme({
     },
     MuiTooltip: {
       tooltip: {
-        fontSize: '.875rem',
-        lineHeight: 1.715,
-        letterSpacing: 0.5
+        fontSize: '.875rem'
       }
     },
     MuiChip: {
@@ -218,19 +216,6 @@ const ReonomyTheme = createMuiTheme({
       deleteIcon: {
         width: `12px`,
         color: '#3C3E41' // grey[800]
-      }
-    },
-    MuiTab: {
-      wrapper: {
-        fontSize: '.875rem',
-        fontWeight: 'normal',
-        lineHeight: 1.715,
-        letterSpacing: 0.5
-      },
-      root: {
-        '&$selected': {
-          fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif"
-        }
       }
     },
     MuiTableCell: {

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -34,27 +34,77 @@ declare module '@material-ui/core/styles/createPalette' {
 const ReonomyTheme = createMuiTheme({
   typography: {
     fontFamily: "'Basier Square Regular', Helvetica, Arial, sans-serif",
+    h1: {
+      fontSize: '6rem',
+      fontWeight: 'normal',
+      lineHeight: 1.167,
+      letterSpacing: -2.5
+    },
+    h2: {
+      fontSize: '4.5rem',
+      fontWeight: 'normal',
+      lineHeight: 1.225,
+      letterSpacing: -1.5
+    },
+    h3: {
+      fontSize: '3.75rem',
+      fontWeight: 'normal',
+      lineHeight: 1.2,
+      letterSpacing: -0.75
+    },
+    h4: {
+      fontSize: '3rem',
+      fontWeight: 'normal',
+      lineHeight: 1.333,
+      letterSpacing: -0.5
+    },
+    h5: {
+      fontSize: '2.5rem',
+      fontWeight: 'normal',
+      lineHeight: 1.4,
+      letterSpacing: -0.25
+    },
     h6: {
-      fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif",
-      fontWeight: 'normal'
+      fontSize: '2rem',
+      fontWeight: 'normal',
+      lineHeight: 1.5,
+      letterSpacing: -0.15
     },
     subtitle1: {
-      fontSize: '1.125rem',
-      lineHeight: '1.33'
+      fontSize: '1.5rem',
+      fontWeight: 'normal',
+      lineHeight: 1.333
     },
     subtitle2: {
-      fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif",
+      fontSize: '1.25rem',
+      fontWeight: 'normal',
+      lineHeight: 1.6,
+      letterSpacing: 0.15
+    },
+    body1: {
       fontSize: '1rem',
-      fontWeight: 'normal'
+      fontWeight: 'normal',
+      lineHeight: 1.5,
+      letterSpacing: 0.25
+    },
+    body2: {
+      fontSize: '.875rem',
+      fontWeight: 'normal',
+      lineHeight: 1.715,
+      letterSpacing: 0.5
     },
     button: {
-      fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif",
+      fontFamily: "'Basier Square SemiBold', Helvetica, Arial, sans-serif",
       fontWeight: 'normal',
+      letterSpacing: 0.5,
       textTransform: 'none'
     },
     overline: {
+      fontSize: '.75rem',
       fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif",
-      fontWeight: 'normal'
+      fontWeight: 'normal',
+      lineHeight: 1.333,
+      letterSpacing: 2
     }
   },
   palette: {
@@ -153,7 +203,9 @@ const ReonomyTheme = createMuiTheme({
     },
     MuiTooltip: {
       tooltip: {
-        fontSize: '.875rem'
+        fontSize: '.875rem',
+        lineHeight: 1.715,
+        letterSpacing: 0.5
       }
     },
     MuiChip: {
@@ -170,7 +222,15 @@ const ReonomyTheme = createMuiTheme({
     },
     MuiTab: {
       wrapper: {
-        fontSize: '.875rem'
+        fontSize: '.875rem',
+        fontWeight: 'normal',
+        lineHeight: 1.715,
+        letterSpacing: 0.5
+      },
+      root: {
+        '&$selected': {
+          fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif"
+        }
       }
     },
     MuiTableCell: {
@@ -179,15 +239,12 @@ const ReonomyTheme = createMuiTheme({
         padding: '8px'
       },
       head: {
-        fontSize: '.875rem'
+        fontSize: '.875rem',
+        fontFamily: "'Basier Square Medium', Helvetica, Arial, sans-serif",
+        fontWeight: 'normal'
       },
       stickyHeader: {
         backgroundColor: 'white'
-      }
-    },
-    MuiCardHeader: {
-      title: {
-        fontSize: '1rem'
       }
     },
     MuiListItemText: {


### PR DESCRIPTION
#### Introducing the `<Text>` component
https://reonomy.atlassian.net/browse/SG-35


Based on the typographical scales from the liminal project 
https://www.figma.com/file/1sDRuHjkM96zSxlFTGtiEa/The-Liminal-Project-(Legacy)?node-id=0%3A1

The idea is that these text components should entirely replace all MUI `<Typography>` components throughout visage _and beyond_. 

TODO: 
- ~change theme.tsx so that all typographical elements are proper scale.~
- ~load Basier Square into storybook (you'll notice below these are still just Helvetica)~
- ~bump version~



![image](https://user-images.githubusercontent.com/5460067/108367341-5d23f400-71c7-11eb-92e4-f4e9957ed916.png)
