### PR TITLE
small Text tweaks

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@material-ui/core": "^4.11.1",
-    "@reonomy/styles": "../reonomy-styles-2.5.0.tgz",
+    "@reonomy/styles": "../reonomy-styles-2.5.1.tgz",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reonomy/styles",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Reonomy Design Styles Library",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -13,7 +13,7 @@ export interface TextProps extends Omit<TypographyProps, 'variant' | 'color'> {
   padded?: boolean;
   fontWeight?: 'regular' | 'medium' | 'semibold'; // 400, 500, 600
   variant?: MuiVariant | 'huge' | 'code';
-  color?: TypographyProps['color'] | 'textDisabled' | 'textHint';
+  color?: TypographyProps['color'] | 'textDisabled' | 'textHint' | 'white';
   component?: React.ElementType;
 }
 
@@ -76,6 +76,9 @@ export function Text({
       break;
     case 'textHint':
       classNames.push(classes.textHint);
+      break;
+    case 'white':
+      classNames.push(classes.textWhite);
       break;
     default:
       muiColor = color;

--- a/src/components/text/style.ts
+++ b/src/components/text/style.ts
@@ -14,6 +14,7 @@ export interface StyleClasses {
   fontWeightSemiBold: string;
   textDisabled: string;
   textHint: string;
+  textWhite: string;
 }
 
 export default makeStyles((theme: Theme) => {
@@ -58,6 +59,9 @@ export default makeStyles((theme: Theme) => {
     },
     textHint: {
       color: theme.palette.text.hint
+    },
+    textWhite: {
+      color: theme.palette.common.white
     }
   };
 });

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -91,7 +91,7 @@ const ReonomyTheme = createMuiTheme({
       fontSize: '.875rem',
       fontWeight: 'normal',
       lineHeight: 1.5,
-      letterSpacing: 0.5
+      letterSpacing: 0.25
     },
     button: {
       fontFamily: "'Basier Square SemiBold', Helvetica, Arial, sans-serif",


### PR DESCRIPTION
Some minor tweaks to the `Text` component after design review

- `body2` size needs .25 letter-spacing
- `white` color text support as this is the remaining most common use case
- bump up minor version